### PR TITLE
Make HistogramBinning clonable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black-jupyter
         language_version: python3

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -27,11 +27,13 @@ def test_notebook(notebook):
     log.info(f"Reading jupyter notebook from {notebook_path}")
     with open(notebook_path) as f:
         nb = nbformat.read(f, as_version=4)
-    ep = ExecutePreprocessor(timeout=600)
-    with ep.setup_preprocessor(nb, resources=resources):
+    ep = ExecutePreprocessor(timeout=600, resource=resources)
+    # HACK: this is needed because some really smart person didn't test correctly the init of ExecutePreprocessor
+    ep.nb = nb
+    with ep.setup_kernel():
         for i, cell in enumerate(nb["cells"]):
             log.info(f"processing cell {i} from {notebook}")
-            ep.preprocess_cell(cell, resources=resources, cell_index=i)
+            ep.preprocess_cell(cell, resources=resources, index=i)
 
     # saving the executed notebook to docs
     output_path = os.path.join(DOCS_DIR, notebook)

--- a/src/kyle/calibration/calibration_methods.py
+++ b/src/kyle/calibration/calibration_methods.py
@@ -86,6 +86,7 @@ class IsotonicRegression(NetcalBasedCalibration[bn.IsotonicRegression]):
 class HistogramBinning(NetcalBasedCalibration[bn.HistogramBinning]):
     def __init__(self, bins=20):
         super().__init__(bn.HistogramBinning(bins=bins))
+        self.bins = bins
 
 
 class ClassWiseCalibration(BaseCalibrationMethod):

--- a/tests/kyle/calibration/calibration_methods/test_calibration_methods.py
+++ b/tests/kyle/calibration/calibration_methods/test_calibration_methods.py
@@ -1,7 +1,13 @@
 import pytest
 from sklearn import clone
 
-from kyle.calibration.calibration_methods import TemperatureScaling
+from kyle.calibration.calibration_methods import (
+    HistogramBinning,
+    TemperatureScaling,
+    IsotonicRegression,
+    BetaCalibration,
+    LogisticCalibration,
+)
 from kyle.metrics import ECE
 
 
@@ -15,6 +21,13 @@ def calibration_method():
     return TemperatureScaling()
 
 
+@pytest.mark.parametrize("calibration_method", [
+    HistogramBinning(),
+    TemperatureScaling(),
+    IsotonicRegression(),
+    BetaCalibration(),
+    LogisticCalibration(),
+])
 def test_calibration_methods_clonability(calibration_method):
     clone(calibration_method)
 

--- a/tests/kyle/calibration/calibration_methods/test_calibration_methods.py
+++ b/tests/kyle/calibration/calibration_methods/test_calibration_methods.py
@@ -1,4 +1,5 @@
 import pytest
+from sklearn import clone
 
 from kyle.calibration.calibration_methods import TemperatureScaling
 from kyle.metrics import ECE
@@ -12,6 +13,10 @@ def metric():
 @pytest.fixture(scope="module")
 def calibration_method():
     return TemperatureScaling()
+
+
+def test_calibration_methods_clonability(calibration_method):
+    clone(calibration_method)
 
 
 def test_methods_calibrationErrorLessAfterCalibration(

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     pytest-xdist
     pytest-lazy-fixture
     jupyter==1.0.0
-    nbconvert==5.6.1
+    nbconvert==6.4.5
     -rrequirements.txt
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
 deps =
     Sphinx==3.2.1
     sphinxcontrib-websupport==1.2.4
+    jinja2<3.1
     sphinx_rtd_theme
     nbsphinx
     ipython


### PR DESCRIPTION
This PR changes HistogramBinning to make it clonable using sklearn's `clone` function.

It also fixes the notebook tests and bumps black's version to fix an issue with click when freshly installing it.